### PR TITLE
Fix reversed P/E-cores reporting on Windows

### DIFF
--- a/crates/gdt-cpus/src/platform/windows/cpu.rs
+++ b/crates/gdt-cpus/src/platform/windows/cpu.rs
@@ -181,7 +181,7 @@ pub fn detect_cpu_info() -> Result<CpuInfo> {
         match info_ex.Relationship {
             RelationProcessorCore => {
                 let proc_core = unsafe { &info_ex.Anonymous.Processor };
-                let core_type = if proc_core.EfficiencyClass != 0 {
+                let core_type = if proc_core.EfficiencyClass == 0 {
                     CoreType::Efficiency
                 } else {
                     CoreType::Performance


### PR DESCRIPTION
Hi,
When cross-compiling to Windows (Intel Core i7-14700KF), I found out that the P/E cores are reversed, on this setup : I get 12P & 8E instead of 8P & 12E.

From windows docs : 
> CpuSet.EfficiencyClass
> 
> A value indicating the intrinsic energy efficiency of a processor for systems that support heterogeneous processors (such as ARM big.LITTLE systems). CPU Sets with higher numerical values of this field have home processors that are faster but less power-efficient than ones with lower values.

It's quite evasive about the possible values...
In my case E-cores are reported as 0, sadly I can't test on any other Windows hybrid cpus..