### PR TITLE
`impl Extend for AffinityMask`

### DIFF
--- a/crates/gdt-cpus/src/affinity_mask.rs
+++ b/crates/gdt-cpus/src/affinity_mask.rs
@@ -417,11 +417,7 @@ impl std::fmt::Debug for Ranges<'_> {
 impl FromIterator<usize> for AffinityMask {
     fn from_iter<T: IntoIterator<Item = usize>>(iter: T) -> Self {
         let mut mask = AffinityMask::empty();
-
-        for id in iter {
-            mask.add(id);
-        }
-
+        mask.extend(iter);
         mask
     }
 }
@@ -529,7 +525,8 @@ mod tests {
     #[test]
     fn test_extend() {
         let mut mask = AffinityMask::from_iter([0, 2, 4]);
-        mask.extend([1, 3]);
+        // The out-of-range id is silently dropped, same as `add`.
+        mask.extend([1, 3, AffinityMask::MAX_LP_COUNT]);
         assert_eq!(mask, AffinityMask::from_iter([0, 1, 2, 3, 4]));
     }
 

--- a/crates/gdt-cpus/src/affinity_mask.rs
+++ b/crates/gdt-cpus/src/affinity_mask.rs
@@ -426,6 +426,17 @@ impl FromIterator<usize> for AffinityMask {
     }
 }
 
+impl Extend<usize> for AffinityMask {
+    fn extend<Iter>(&mut self, iter: Iter)
+    where
+        Iter: IntoIterator<Item = usize>,
+    {
+        for core in iter {
+            self.add(core);
+        }
+    }
+}
+
 impl IntoIterator for &AffinityMask {
     type Item = usize;
     type IntoIter = std::vec::IntoIter<usize>;
@@ -513,6 +524,13 @@ mod tests {
         assert!(mask.contains(0));
         assert!(mask.contains(2));
         assert!(mask.contains(4));
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut mask = AffinityMask::from_iter([0, 2, 4]);
+        mask.extend([1, 3]);
+        assert_eq!(mask, AffinityMask::from_iter([0, 1, 2, 3, 4]));
     }
 
     // A fixed backing array makes equality canonical: add-then-remove of a


### PR DESCRIPTION
I had the following piece of code that was parsing CPU sets from a string, which used `.extend()`:
```rust
/// Parse space-separated set of groups of CPU cores (individual cores are coma-separated) into
/// vector of CPU core sets that can be used for creation of plotting/replotting thread pools.
pub fn parse_cpu_cores_sets(
    s: &str,
) -> Result<Vec<CpuCoreSet>, Box<dyn std::error::Error + Send + Sync>> {
    let cpu_info = CpuInfo::detect().ok().map(Arc::new);

    s.split(' ')
        .map(|s| {
            let mut cores = AffinityMask::empty();
            for s in s.split(',') {
                let mut parts = s.split('-');
                let range_start = parts
                    .next()
                    .ok_or(
                        "Bad string format, must be comma separated list of CPU cores or ranges",
                    )?
                    .parse()?;

                if let Some(range_end) = parts.next() {
                    let range_end = range_end.parse()?;

                    cores.extend(range_start..=range_end);
                } else {
                    cores.add(range_start);
                }
            }

            Ok(CpuCoreSet {
                affinity_mask: cores,
                cpu_info: cpu_info.clone(),
            })
        })
        .collect()
}
```

With this change it works as is, while previously it required a manual loop.

This is a natural extension of other iterator-related APIs (`impl Iterator for AffinityMask` would have been nice too).